### PR TITLE
11 fix swagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ init:
 	mkdir front/node_modules
 	docker compose run --rm front npm install
 
-install_back:
-	docker compose run --rm back pip install -r requirements.txt
+back_test:
+	docker compose run --rm back pytest
 
 create_app:
 	docker compose run --rm back ./manage.py startapp ${i}

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -18,6 +18,8 @@ COPY --chown=$USERNAME:$USERNAME requirements.txt $WORKPATH
 
 RUN pip install -r requirements.txt
 
+ENV DJANGO_SETTINGS_MODULE=back.settings
+
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
 
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/back/api/support/swagger.yml
+++ b/back/api/support/swagger.yml
@@ -1,18 +1,16 @@
 openapi: 3.0.0
 info:
-  title: Sample API
-  description: API documentation for your Django project
-  version: "1.0.0"
-servers:
-  - url: http://localhost:8000
+  title: API V1
+  description: This is a sample API documentation using OpenAPI 3.0.
+  version: 1.0.0
 paths:
-  /api/sample:
+  v1/animals:
     get:
-      summary: Sample GET endpoint
-      description: Returns a list of samples
+      summary: Get a list of animals
+      description: Retrieve a list of all animals in the database.
       responses:
         '200':
-          description: A list of samples
+          description: A list of animals
           content:
             application/json:
               schema:
@@ -24,3 +22,39 @@ paths:
                       type: integer
                     name:
                       type: string
+                    age:
+                      type: integer
+                    species:
+                      type: string
+    post:
+      summary: Create a new animal
+      description: Add a new animal to the database.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                age:
+                  type: integer
+                species:
+                  type: string
+      responses:
+        '201':
+          description: The animal was created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  age:
+                    type: integer
+                  species:
+                    type: string

--- a/back/api/support/swagger.yml
+++ b/back/api/support/swagger.yml
@@ -3,6 +3,10 @@ info:
   title: API V1
   description: This is a sample API documentation using OpenAPI 3.0.
   version: 1.0.0
+
+tags:
+  - name: Animals
+    description: Operations related to animal resources
 paths:
   v1/animals:
     get:
@@ -58,3 +62,106 @@ paths:
                     type: integer
                   species:
                     type: string
+        '400':
+          description: Malformed animal request
+          content:
+            application/json:
+              schema:
+                type: object
+
+  v1/animals/:id:
+    get:
+      summary: Get an animal
+      description: Retrieve a matching animal with the given id from the database.
+      responses:
+        '200':
+          description: A list of animals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    age:
+                      type: integer
+                    species:
+                      type: string
+        '404':
+          description: Animal not found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+    delete:
+      summary: Get an animal
+      description: Retrieve a matching animal with the given id from the database.
+      responses:
+        '200':
+          description: A list of animals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    age:
+                      type: integer
+                    species:
+                      type: string
+        '404':
+          description: Animal not found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+    put:
+      summary: Update an animal
+      description: Updates a matching animal with the given information.
+      responses:
+        '200':
+          description: A list of animals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    name:
+                      type: string
+                    age:
+                      type: integer
+                    species:
+                      type: string
+        '404':
+          description: Animal not found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object

--- a/back/api/test/endpoints/get_animals_test.py
+++ b/back/api/test/endpoints/get_animals_test.py
@@ -1,0 +1,28 @@
+import unittest
+from django.test import Client, TestCase, SimpleTestCase
+
+class TestAnimals(unittest.TestCase):
+    c = Client()
+
+    def test_get_all_animals(self):
+        show_endpoint = '/v1/animals/'
+
+        response = self.c.get(show_endpoint)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_animal_given_id(self):
+        id = 0
+        index_endpoint = f'/v1/animals/{id}'
+
+        response = self.c.get(index_endpoint)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_404_when_no_animal_found(self):
+        id = 110
+        index_endpoint = f'/v1/animals/{id}'
+
+        response = self.c.get(index_endpoint)
+
+        self.assertEqual(response.status_code, 404)

--- a/back/api/test/harness_test.py
+++ b/back/api/test/harness_test.py
@@ -1,0 +1,9 @@
+import unittest
+
+class TestHarness(unittest.TestCase):
+
+    def _test_harness(self):
+        self.assertTrue(True)
+
+    def _test_equal(self):
+        self.assertEqual(['foo'], ['foo'])

--- a/back/api/urls.py
+++ b/back/api/urls.py
@@ -4,21 +4,21 @@ from rest_framework import permissions
 from rest_framework.routers import DefaultRouter
 
 from .views.animal_view import Animals
-from .views.swagger import Swagger
+# from .views.swagger import Swagger
 
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
+# from drf_yasg.views import get_schema_view
+# from drf_yasg import openapi
 
-schema_view = get_schema_view(
-   openapi.Info(
-      title="Sample API",
-      default_version='v1',
-      description="API documentation for your Django project",
-      contact=openapi.Contact(email="your-email@example.com"),
-   ),
-   public=True,
-   # permission_classes=(permissions.AllowAny,),
-)
+# schema_view = get_schema_view(
+#    openapi.Info(
+#       title="Sample API",
+#       default_version='v1',
+#       description="API documentation for your Django project",
+#       contact=openapi.Contact(email="your-email@example.com"),
+#    ),
+#    public=True,
+#    # permission_classes=(permissions.AllowAny,),
+# )
 
 # router = DefaultRouter()
 # router.register(r'animals', Animals, basename='animal')
@@ -26,5 +26,5 @@ schema_view = get_schema_view(
 urlpatterns = [
     path('animals/', Animals.as_view(), name='animals'),
     path('animals/<int:id>', Animals.as_view(), name='animals'),
-    path('docs/', schema_view.with_ui('swagger', cache_timeout=0), name='swagger-ui')
+   #  path('docs/', schema_view.with_ui('swagger', cache_timeout=0), name='swagger-ui')
 ]

--- a/back/api/urls.py
+++ b/back/api/urls.py
@@ -3,28 +3,19 @@ from django.urls import path, include #type: ignore
 from rest_framework import permissions
 from rest_framework.routers import DefaultRouter
 
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView
+)
+
 from .views.animal_view import Animals
-# from .views.swagger import Swagger
-
-# from drf_yasg.views import get_schema_view
-# from drf_yasg import openapi
-
-# schema_view = get_schema_view(
-#    openapi.Info(
-#       title="Sample API",
-#       default_version='v1',
-#       description="API documentation for your Django project",
-#       contact=openapi.Contact(email="your-email@example.com"),
-#    ),
-#    public=True,
-#    # permission_classes=(permissions.AllowAny,),
-# )
-
-# router = DefaultRouter()
-# router.register(r'animals', Animals, basename='animal')
 
 urlpatterns = [
     path('animals/', Animals.as_view(), name='animals'),
     path('animals/<int:id>', Animals.as_view(), name='animals'),
-   #  path('docs/', schema_view.with_ui('swagger', cache_timeout=0), name='swagger-ui')
+
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/back/api/urls.py
+++ b/back/api/urls.py
@@ -4,18 +4,18 @@ from rest_framework import permissions
 from rest_framework.routers import DefaultRouter
 
 from drf_spectacular.views import (
-    SpectacularAPIView,
     SpectacularRedocView,
     SpectacularSwaggerView
 )
 
 from .views.animal_view import Animals
+from .views.swagger import CustomSchemaView
 
 urlpatterns = [
     path('animals/', Animals.as_view(), name='animals'),
     path('animals/<int:id>', Animals.as_view(), name='animals'),
 
-    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
-    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/', CustomSchemaView.as_view(), name='custom-schema'),
+    path('api/docs/',SpectacularSwaggerView.as_view(url_name='custom-schema'), name='swagger-ui'),
     path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]

--- a/back/api/views/swagger.py
+++ b/back/api/views/swagger.py
@@ -1,27 +1,27 @@
-from django.conf import settings
+# from django.conf import settings
 
-from rest_framework.decorators import APIView # type: ignore
-from rest_framework.response import Response
-from rest_framework.permissions import AllowAny
-from rest_framework import status
-# from django.http import JsonResponse # type: ignore
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
-from drf_yasg.views import get_schema_view
+# from rest_framework.decorators import APIView # type: ignore
+# from rest_framework.response import Response
+# from rest_framework.permissions import AllowAny
+# from rest_framework import status
+# # from django.http import JsonResponse # type: ignore
+# from drf_yasg import openapi
+# from drf_yasg.utils import swagger_auto_schema
+# from drf_yasg.views import get_schema_view
 
-from api.support.repository import Repository
+# from api.support.repository import Repository
 
-import os, yaml, json, sys
+# import os, yaml, json, sys
 
-class Swagger(APIView):
-    permission_classes = [AllowAny]
+# class Swagger(APIView):
+#     permission_classes = [AllowAny]
 
-    def get(self, request):
-        # Load the YAML file
-        yaml_path = '/opt/workdir/api/support/swagger.yml'
-        with open(yaml_path, 'r') as yaml_file:
-            yaml_content = yaml.safe_load(yaml_file)
+#     def get(self, request):
+#         # Load the YAML file
+#         yaml_path = '/opt/workdir/api/support/swagger.yml'
+#         with open(yaml_path, 'r') as yaml_file:
+#             yaml_content = yaml.safe_load(yaml_file)
 
-        # Convert the loaded YAML content to an OpenAPI schema
-            openapi_schema = openapi.Swagger(yaml_content)
-        return Response(openapi_schema, status=status.HTTP_200_OK)
+#         # Convert the loaded YAML content to an OpenAPI schema
+#             openapi_schema = openapi.Swagger(yaml_content)
+#         return Response(openapi_schema, status=status.HTTP_200_OK)

--- a/back/api/views/swagger.py
+++ b/back/api/views/swagger.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+import logging
 from django.http import JsonResponse
 from django.conf import settings
 from rest_framework.views import APIView
@@ -16,4 +17,5 @@ class CustomSchemaView(APIView):
         except FileNotFoundError:
             return JsonResponse({'error': 'Schema file not found.'}, status=404)
         except yaml.YAMLError as e:
-            return JsonResponse({'error': f'Error parsing YAML: {str(e)}'}, status=500)
+            logging.error(f'Error parsing YAML: {str(e)}')
+            return JsonResponse({'error': 'An internal error has occurred while parsing the schema.'}, status=500)

--- a/back/api/views/swagger.py
+++ b/back/api/views/swagger.py
@@ -1,24 +1,19 @@
+import os
+import yaml
+from django.http import JsonResponse
 from django.conf import settings
+from rest_framework.views import APIView
 
-from rest_framework.decorators import APIView # type: ignore
-from rest_framework.response import Response
-from rest_framework.permissions import AllowAny
-from rest_framework import status
-# from django.http import JsonResponse # type: ignore
-
-from api.support.repository import Repository
-
-import os, yaml, json, sys
-
-# class Swagger(APIView):
-#     permission_classes = [AllowAny]
-
-#     def get(self, request):
-#         # Load the YAML file
-#         yaml_path = '/opt/workdir/api/support/swagger.yml'
-#         with open(yaml_path, 'r') as yaml_file:
-#             yaml_content = yaml.safe_load(yaml_file)
-
-#         # Convert the loaded YAML content to an OpenAPI schema
-#             openapi_schema = openapi.Swagger(yaml_content)
-#         return Response(openapi_schema, status=status.HTTP_200_OK)
+class CustomSchemaView(APIView):
+    def get(self, request, *args, **kwargs):
+        # Path to your swagger.yml file
+        schema_path = '/opt/workdir/api/support/swagger.yml'  # Use the absolute path in Docker
+        try:
+            with open(schema_path, 'r') as file:
+                # Load YAML content and convert it to a dictionary
+                schema_data = yaml.safe_load(file)
+            return JsonResponse(schema_data)
+        except FileNotFoundError:
+            return JsonResponse({'error': 'Schema file not found.'}, status=404)
+        except yaml.YAMLError as e:
+            return JsonResponse({'error': f'Error parsing YAML: {str(e)}'}, status=500)

--- a/back/api/views/swagger.py
+++ b/back/api/views/swagger.py
@@ -1,17 +1,14 @@
-# from django.conf import settings
+from django.conf import settings
 
-# from rest_framework.decorators import APIView # type: ignore
-# from rest_framework.response import Response
-# from rest_framework.permissions import AllowAny
-# from rest_framework import status
-# # from django.http import JsonResponse # type: ignore
-# from drf_yasg import openapi
-# from drf_yasg.utils import swagger_auto_schema
-# from drf_yasg.views import get_schema_view
+from rest_framework.decorators import APIView # type: ignore
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
+from rest_framework import status
+# from django.http import JsonResponse # type: ignore
 
-# from api.support.repository import Repository
+from api.support.repository import Repository
 
-# import os, yaml, json, sys
+import os, yaml, json, sys
 
 # class Swagger(APIView):
 #     permission_classes = [AllowAny]

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -62,12 +62,15 @@ SPECTACULAR_SETTINGS = {
     'TITLE': 'My API',
     'DESCRIPTION': 'This is a sample API documentation using OpenAPI 3.0.',
     'VERSION': '1.0.0',
-    'SERVE_INCLUDE_SCHEMA': False,
+    'SERVE_INCLUDE_SCHEMA': True,
     'SWAGGER_UI_SETTINGS': {
         'deepLinking': True,
         'defaultModelRendering': 'model',
         'displayRequestDuration': True,
     },
+    'TAGS': [
+        {'name': 'Animals'}
+    ],
     # Load the external schema file
     'SCHEMA_PATH': os.path.join(BASE_DIR, 'api/support/swagger.yml'),
 }

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
 from pathlib import Path
+import os, sys
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -55,12 +56,23 @@ REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema'
 }
 
+BASE_DIR = Path(__file__).resolve().parent.parent
+
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'Petsync-API',
-    'DESCRIPTION': 'API for all petsync requests',
+    'TITLE': 'My API',
+    'DESCRIPTION': 'This is a sample API documentation using OpenAPI 3.0.',
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
+    'SWAGGER_UI_SETTINGS': {
+        'deepLinking': True,
+        'defaultModelRendering': 'model',
+        'displayRequestDuration': True,
+    },
+    # Load the external schema file
+    'SCHEMA_PATH': os.path.join(BASE_DIR, 'api/support/swagger.yml'),
 }
+
+print(os.path.join(BASE_DIR, 'api/support/swagger.yml'), file=sys.stderr)
 
 CORS_ALLOW_CREDENTIALS = True
 # Application definition
@@ -110,7 +122,6 @@ WSGI_APPLICATION = 'back.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
-import os
 
 DATABASES = {
     'default': {

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -51,11 +51,22 @@ CORS_ALLOW_HEADERS = (
     "x-requested-with",
 )
 
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema'
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Petsync-API',
+    'DESCRIPTION': 'API for all petsync requests',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
+}
+
 CORS_ALLOW_CREDENTIALS = True
 # Application definition
 
 INSTALLED_APPS = [
-    # 'drf_yasg',
+    'drf_spectacular',
     'api.apps.ApiConfig',
     'django.contrib.admin',
     'django.contrib.auth',
@@ -69,7 +80,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    # 'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/back/back/settings.py
+++ b/back/back/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 from pathlib import Path
 
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -54,7 +55,7 @@ CORS_ALLOW_CREDENTIALS = True
 # Application definition
 
 INSTALLED_APPS = [
-    'drf_yasg',
+    # 'drf_yasg',
     'api.apps.ApiConfig',
     'django.contrib.admin',
     'django.contrib.auth',
@@ -98,13 +99,18 @@ WSGI_APPLICATION = 'back.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
+import os
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('DB_NAME'),
+        'USER': os.getenv('DB_USER'),
+        'PASSWORD': os.getenv('DB_PASSWORD'),
+        'HOST': os.getenv('DB_HOST'),
+        'PORT': '5432',  # Default PostgreSQL port
     }
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -3,12 +3,14 @@ django-cors-headers==4.3.1
 djangorestframework==3.15.1
 
 PyJWT==2.8.0
+pytest==8.3.3
+pytest-django==4.9.0
 psycopg2-binary>=2.8
 
 redgreenunittest
 google-auth==2.31.0
 
 requests
-django-rest-swagger
-drf-yasg
+# django-rest-swagger
+# drf-yasg
 pyyaml

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -11,6 +11,5 @@ redgreenunittest
 google-auth==2.31.0
 
 requests
-# django-rest-swagger
-# drf-yasg
+drf-spectacular
 pyyaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     depends_on:
       - postgres
     volumes:
-      # - front_modules:/opt/workdir/node_modules
       - type: bind
         source: ./back
         target: /opt/workdir
@@ -41,6 +40,7 @@ services:
       POSTGRES_DB: mydatabase
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword
+      # DJANGO_SETTINGS_MODULE: back.settings
 
   django_scaffolder:
     build:


### PR DESCRIPTION
Hay un swagger.yml en la ruta back/api/support/swagger.yml

Ahí están todos los endpoinst descritos para swagger con la información necesaria. El día que haga falta se puede modificar todo lo referente a la documentación de los endpoints desde ese archivo.

Para cambiar el comportamiento de las vistas es más complejo, pero hay una vista dentro de api/views/swagger.py llamada customSchemaView.